### PR TITLE
Add tooltip to edit Emoji, change behaviour of set main account.

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -366,8 +366,8 @@ PODS:
     - React-Core
   - RNCClipboard (1.5.1):
     - React-Core
-  - RNCMaskedView (0.1.11):
-    - React
+  - RNCMaskedView (0.2.6):
+    - React-Core
   - RNDeviceInfo (8.4.8):
     - React-Core
   - RNGestureHandler (1.10.3):
@@ -479,7 +479,7 @@ DEPENDENCIES:
   - rn-fetch-blob (from `../node_modules/rn-fetch-blob`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - "RNCClipboard (from `../node_modules/@react-native-community/clipboard`)"
-  - "RNCMaskedView (from `../node_modules/@react-native-community/masked-view`)"
+  - "RNCMaskedView (from `../node_modules/@react-native-masked-view/masked-view`)"
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNReactNativeHapticFeedback (from `../node_modules/react-native-haptic-feedback`)
@@ -592,7 +592,7 @@ EXTERNAL SOURCES:
   RNCClipboard:
     :path: "../node_modules/@react-native-community/clipboard"
   RNCMaskedView:
-    :path: "../node_modules/@react-native-community/masked-view"
+    :path: "../node_modules/@react-native-masked-view/masked-view"
   RNDeviceInfo:
     :path: "../node_modules/react-native-device-info"
   RNGestureHandler:
@@ -666,7 +666,7 @@ SPEC CHECKSUMS:
   rn-fetch-blob: f065bb7ab7fb48dd002629f8bdcb0336602d3cba
   RNCAsyncStorage: 0bef6a21517c0254bd6bd59a3672963abfa0d18e
   RNCClipboard: 41d8d918092ae8e676f18adada19104fa3e68495
-  RNCMaskedView: 0e1bc4bfa8365eba5fbbb71e07fbdc0555249489
+  RNCMaskedView: c298b644a10c0c142055b3ae24d83879ecb13ccd
   RNDeviceInfo: 0400a6d0c94186d1120c3cbd97b23abc022187a9
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNReactNativeHapticFeedback: b83bfb4b537bdd78eb4f6ffe63c6884f7b049ead

--- a/src/modals/CreateEditAccount/index.js
+++ b/src/modals/CreateEditAccount/index.js
@@ -1,18 +1,20 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { StyleSheet, View, Text } from 'react-native';
+import { View, Text } from 'react-native';
 
-import RainbowButton from '../components/buttons/RainbowButton';
-import TextInput from '../components/common/TextInput';
-import UserIcon from '../components/common/UserIcon';
-import Header from '../components/common/Header';
-import { FontStyles } from '../constants/theme';
-import useAccounts from '../hooks/useAccounts';
-import EmojiSelector from './EmojiSelector';
-import Modal from '../components/modal';
+import RainbowButton from '../../components/buttons/RainbowButton';
+import TextInput from '../../components/common/TextInput';
+import UserIcon from '../../components/common/UserIcon';
+import Header from '../../components/common/Header';
+import { FontStyles } from '../../constants/theme';
+import useAccounts from '../../hooks/useAccounts';
+import EmojiSelector from '../EmojiSelector';
+import Modal from '../../components/modal';
+import styles from './styles';
 
 const CreateEditAccount = ({ modalRef, account, ...props }) => {
   const editEmojiRef = useRef(null);
   const [accountName, setAccountName] = useState('');
+  const [editTouched, setEditTouched] = useState(false);
   const [emoji, setEmoji] = useState('');
 
   const { onCreate, onEdit } = useAccounts();
@@ -40,6 +42,7 @@ const CreateEditAccount = ({ modalRef, account, ...props }) => {
 
   const onEditEmoji = () => {
     editEmojiRef?.current.open();
+    setEditTouched(true);
   };
 
   const getName = () => `${account ? 'Edit' : 'Create'} Account`;
@@ -59,13 +62,21 @@ const CreateEditAccount = ({ modalRef, account, ...props }) => {
       {...props}>
       <Header center={<Text style={FontStyles.Subtitle2}>{getName()}</Text>} />
       <View style={styles.content}>
-        <UserIcon
-          icon={emoji}
-          size="extralarge"
-          style={styles.icon}
-          onPress={onEditEmoji}
-        />
-
+        <View>
+          <UserIcon
+            icon={emoji}
+            size="extralarge"
+            style={styles.icon}
+            onPress={onEditEmoji}
+          />
+          {!editTouched && (
+            <View style={styles.toolTip}>
+              <Text style={[FontStyles.Small, styles.toolTipText]}>
+                👈 Edit
+              </Text>
+            </View>
+          )}
+        </View>
         <TextInput
           placeholder="Account name"
           variant="text"
@@ -74,13 +85,11 @@ const CreateEditAccount = ({ modalRef, account, ...props }) => {
           autoFocus
           customStyle={styles.input}
         />
-
         <RainbowButton
           text={getName()}
           onPress={onPress}
           disabled={!accountName}
         />
-
         <EmojiSelector
           modalRef={editEmojiRef}
           onSave={setEmoji}
@@ -92,18 +101,3 @@ const CreateEditAccount = ({ modalRef, account, ...props }) => {
 };
 
 export default CreateEditAccount;
-
-const styles = StyleSheet.create({
-  content: {
-    paddingHorizontal: 20,
-    paddingTop: 20,
-    paddingBottom: 35,
-  },
-  icon: {
-    alignSelf: 'center',
-    marginBottom: 25,
-  },
-  input: {
-    marginBottom: 25,
-  },
-});

--- a/src/modals/CreateEditAccount/styles.js
+++ b/src/modals/CreateEditAccount/styles.js
@@ -1,0 +1,32 @@
+import { StyleSheet } from 'react-native';
+
+import { Colors } from '../../constants/theme';
+
+export default StyleSheet.create({
+  content: {
+    paddingHorizontal: 20,
+    paddingTop: 20,
+    paddingBottom: 35,
+  },
+  icon: {
+    alignSelf: 'center',
+    marginBottom: 25,
+  },
+  input: {
+    marginBottom: 25,
+  },
+  toolTip: {
+    backgroundColor: '#FFEEDC',
+    borderRadius: 32,
+    position: 'absolute',
+    width: 71,
+    height: 30,
+    alignItems: 'center',
+    justifyContent: 'center',
+    right: 55,
+    bottom: 43,
+  },
+  toolTipText: {
+    color: Colors.Black.Pure,
+  },
+});

--- a/src/screens/Accounts/index.js
+++ b/src/screens/Accounts/index.js
@@ -3,21 +3,21 @@ import { useDispatch, useSelector } from 'react-redux';
 import React, { useRef, useState } from 'react';
 
 import { reset, setCurrentPrincipal } from '../../redux/slices/keyring';
-import { getNFTs } from '../../redux/slices/user';
+import CreateEditAccount from '../../modals/CreateEditAccount';
 import Touchable from '../../components/animations/Touchable';
 import AccountItem from '../../components/common/AccountItem';
-import CreateEditAccount from '../../modals/CreateEditAccount';
 import shortAddress from '../../helpers/short-address';
 import { useICPPrice } from '../../redux/slices/icp';
 import Header from '../../components/common/Header';
 import { FontStyles } from '../../constants/theme';
+import { getNFTs } from '../../redux/slices/user';
 import Row from '../../components/layout/Row';
 import Modal from '../../components/modal';
 import Icon from '../../components/icons';
 import styles from './styles';
 
 const Accounts = ({ modalRef, onClose, ...props }) => {
-  const { wallets } = useSelector(state => state.keyring);
+  const { wallets, currentWallet } = useSelector(state => state.keyring);
   const icpPrice = useICPPrice();
   const dispatch = useDispatch();
   const [loading, setLoading] = useState(false);
@@ -67,6 +67,23 @@ const Accounts = ({ modalRef, onClose, ...props }) => {
     );
   };
 
+  const renderAccountItem = (account, index) => {
+    const handleOnPress = () => {
+      if (currentWallet.principal !== account.principal) {
+        onChangeAccount(account?.walletNumber);
+      }
+    };
+
+    return (
+      <AccountItem
+        key={index}
+        account={account}
+        onPress={handleOnPress}
+        onMenu={() => onLongPress(account)}
+      />
+    );
+  };
+
   return (
     <Modal adjustToContentHeight modalRef={modalRef} {...props}>
       <Header center={<Text style={FontStyles.Subtitle2}>Accounts</Text>} />
@@ -82,16 +99,9 @@ const Accounts = ({ modalRef, onClose, ...props }) => {
             />
           </View>
         )}
-        {wallets?.map((account, index) => (
-          <AccountItem
-            account={account}
-            key={index}
-            onMenu={() => onLongPress(account)}
-            onPress={() => onChangeAccount(account?.walletNumber)}
-          />
-        ))}
+        {wallets?.map(renderAccountItem)}
         <Touchable onPress={onCreateAccount}>
-          <Row align="center" style={{ marginBottom: 30, marginTop: 10 }}>
+          <Row align="center" style={styles.row}>
             <Icon name="plus" />
             <Text style={FontStyles.Normal}> Create account</Text>
           </Row>

--- a/src/screens/Accounts/styles.js
+++ b/src/screens/Accounts/styles.js
@@ -14,4 +14,8 @@ export default StyleSheet.create({
   activityIndicator: {
     ...StyleSheet.absoluteFill,
   },
+  row: {
+    marginBottom: 30,
+    marginTop: 10,
+  },
 });


### PR DESCRIPTION
## Summary

- Add tooltip to encourage user to change the emoji when creating a new sub-account.
- Change behaviour of change main account: Now if the main account that the user selects is the same as the current one, it will do nothing. If it's different it will set the selected account as main.

## Screenshots

*If is not the same account behaviour:*
![IfNotTheSame](https://user-images.githubusercontent.com/44204622/151041220-c7fccb3e-c855-45b1-8ba0-5b0547a3312d.gif)

*If is the same account behaviour:*
![IfTheSame](https://user-images.githubusercontent.com/44204622/151041194-4c244717-1a16-406a-a531-3d03c4baac1d.gif)

*ToolTip behaviour:*
![ToolTip](https://user-images.githubusercontent.com/44204622/151041166-45f9acf4-d04c-4813-9e20-aa841056e07c.gif)

## Notion Ticket

https://www.notion.so/860acccea5a8443aa9479260b8a453fb?v=df094875b8b34fa99c81f2b23171c393&p=987ad974d8014fa999eba111bcff44df
