### PR TITLE
[FIX] NFT display

### DIFF
--- a/src/components/common/NftDisplayer/components/ImageDisplayer/index.js
+++ b/src/components/common/NftDisplayer/components/ImageDisplayer/index.js
@@ -28,7 +28,7 @@ function ImageDisplayer({ style, type, url, isSendView }) {
         <SvgCssUri {...imageStyle} uri={url} />
       ) : (
         <Image
-          resizeMode="cover"
+          resizeMode="contain"
           style={imageStyle}
           source={{ uri: url, type }}
         />


### PR DESCRIPTION
## Summary

-Change resize mode of images in NFT Display.

## Screenshots

![image](https://user-images.githubusercontent.com/44204622/157719844-76b4899a-c60b-4b69-b451-9d68a91b230f.png)

## Notion Ticket

https://www.notion.so/860acccea5a8443aa9479260b8a453fb?v=df094875b8b34fa99c81f2b23171c393&p=a7e80bb7409343988f9951675a458e6a
