### PR TITLE
Fixed decimal in token value

### DIFF
--- a/src/components/formatters/TokenFormat/index.js
+++ b/src/components/formatters/TokenFormat/index.js
@@ -8,6 +8,7 @@ function TokenFormat({ value, token, style }) {
       value={value}
       displayType="text"
       thousandSeparator=","
+      fixedDecimalScale
       decimalScale={value > 0 ? 8 : 2}
       suffix={` ${token}`}
       renderText={textValue => <Text style={style}>{textValue}</Text>}

--- a/src/screens/auth/CreatePassword/index.js
+++ b/src/screens/auth/CreatePassword/index.js
@@ -95,7 +95,7 @@ const CreatePassword = ({ route, navigation }) => {
           </View>
         }
       />
-      <KeyboardScrollView>
+      <KeyboardScrollView keyboardShouldPersistTaps="always">
         <View style={styles.container}>
           <Text style={styles.title}>{t('createPassword.title')}</Text>
           <Text style={styles.subtitle}>{t('createPassword.subtitle')}</Text>

--- a/src/screens/auth/ImportSeedPhrase/index.js
+++ b/src/screens/auth/ImportSeedPhrase/index.js
@@ -83,7 +83,7 @@ const ImportSeedPhrase = ({ navigation, route }) => {
           </View>
         }
       />
-      <KeyboardScrollView>
+      <KeyboardScrollView keyboardShouldPersistTaps="always">
         <View style={styles.container}>
           <Text style={styles.title}>{t('importSeedPhrase.title')}</Text>
           <Text style={styles.subtitle}>


### PR DESCRIPTION
## Summary
* Added prop to use decimals always
* Keeping keyboard open in password and seed screens

## Notion Ticket
[Ticket](https://www.notion.so/860acccea5a8443aa9479260b8a453fb?v=4f9fe61232824265ba5adebf9dadf5f2&p=7bc0f96bb32c4ab8bb98af16f3313044)
