### PR TITLE
Type icon was underneath the transaction icon on Android

### DIFF
--- a/src/screens/tabs/components/ActivityIcon/styles.js
+++ b/src/screens/tabs/components/ActivityIcon/styles.js
@@ -1,14 +1,18 @@
-import { StyleSheet } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 
 const rootSize = 41;
 const activitySize = 19;
+
+const zIndexStyle = Platform.select({
+  ios: { zIndex: 1 },
+  android: { elevation: 1 },
+});
 
 export default StyleSheet.create({
   root: {
     height: rootSize,
     width: rootSize,
     borderRadius: 26,
-    position: 'relative',
     marginRight: 12,
   },
   activity: {
@@ -16,9 +20,9 @@ export default StyleSheet.create({
     right: -5,
     top: -5,
     borderRadius: 26,
-    zIndex: 1,
     height: activitySize,
     width: activitySize,
+    ...zIndexStyle,
   },
   activityImage: {
     borderRadius: 22,


### PR DESCRIPTION
## Summary

- The type icon was underneath the transaction icon.

## Screenshots

Checked already in both OS, working fine:
![image](https://user-images.githubusercontent.com/44204622/173660919-9d36483d-4c83-4957-8d4e-18df0256494e.png)

