### PR TITLE
[FIX] Show name when already saved contact.

### DIFF
--- a/src/translations/en/index.js
+++ b/src/translations/en/index.js
@@ -162,7 +162,7 @@ const translations = {
     namePlaceholder: 'Name',
     idPlaceholder: 'Principal ID',
     nameTaken: 'Name is already taken!',
-    contactAlreadySaved: 'Contact already saved as {{name}}',
+    contactAlreadySaved: 'Contact already saved as {{value}}',
   },
   placeholders: {
     amount: `0${decimalSeparator}00`,


### PR DESCRIPTION
## Summary

Fix showing `{{name}}` when saving an already saved contact.

## Screenshots

![image](https://user-images.githubusercontent.com/44204622/173676898-7a1df199-86ea-4aee-ad06-9f2b7caeceb8.png)

## Notion Ticket

https://www.notion.so/860acccea5a8443aa9479260b8a453fb?v=4f9fe61232824265ba5adebf9dadf5f2&p=0e25f5ec89ed478dbdd67d234cde278c
