### PR TITLE
Fixed conversion in max button

### DIFF
--- a/src/screens/flows/Send/components/AmountSection/index.tsx
+++ b/src/screens/flows/Send/components/AmountSection/index.tsx
@@ -82,7 +82,7 @@ const AmountSection = ({
   const handleMaxPress = () => {
     setTokenAmount({
       value: availableAmount,
-      display: availableAmount.toFixed(VISIBLE_DECIMALS),
+      display: toFixedLocale(availableAmount, VISIBLE_DECIMALS),
     });
 
     setUsdAmount(


### PR DESCRIPTION
## Summary
Fixed error when converting amount in comma decimal separator regions
