### PR TITLE
Fix/Override dark-mode alert colors

### DIFF
--- a/android/app/src/main/res/values-night/colors.xml
+++ b/android/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="alert_background">#1E1F27</color>
+    <color name="alert_text">#ffffff</color>
+</resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,3 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="bootsplash_background">#15161C</color>
+    <color name="alert_background">#ffffff</color>
+    <color name="alert_text">#0f2438</color>
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -4,6 +4,7 @@
     <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="android:textColor">#000000</item>
+        <item name="android:alertDialogTheme">@style/AlertDialogTheme</item>
     </style>
 
     <!-- BootTheme should inherit from Theme.SplashScreen -->
@@ -11,6 +12,12 @@
         <item name="windowSplashScreenBackground">@color/bootsplash_background</item>
         <item name="windowSplashScreenAnimatedIcon">@mipmap/bootsplash_logo</item>
         <item name="postSplashScreenTheme">@style/AppTheme</item>
+    </style>
+
+    <style name="AlertDialogTheme" parent="Base.Theme.AppCompat.Light.Dialog.Alert">
+        <item name="android:background">@color/alert_background</item>
+        <item name="android:textColor">@color/alert_text</item>
+        <item name="android:textColorPrimary">@color/alert_text</item>
     </style>
 
 </resources>


### PR DESCRIPTION
## Summary
Solved react-native issue with dark-mode alerts

Solution: https://github.com/facebook/react-native/issues/28502#issuecomment-1029952797

## Screenshots
<img width="562" alt="Screen Shot 2022-09-12 at 11 54 15" src="https://user-images.githubusercontent.com/25931366/189686813-df3133e7-4636-4dcc-bc97-8e482daf8a06.png">

<img width="562" alt="Screen Shot 2022-09-12 at 11 53 27" src="https://user-images.githubusercontent.com/25931366/189686899-d1b4aed5-1af5-4efa-a4fc-415cfa48a2a3.png">


## Github Issue
https://github.com/Psychedelic/plug-mobile/issues/426
